### PR TITLE
Implement URN slice support in lookup and rendering components

### DIFF
--- a/examples/company/main.go
+++ b/examples/company/main.go
@@ -37,10 +37,6 @@ func main() {
 		panic(err)
 	}
 
-	/*for i := 0; i < 100; i++ {
-		folio.Insert(db, docs.NewPerson(), "sys")
-	}*/
-
 	if err := render.ListenAndServe(7000, reg, db); err != nil {
 		slog.Error("Failed to start server!", "details", err.Error())
 		os.Exit(1)

--- a/render/html_edit.templ
+++ b/render/html_edit.templ
@@ -207,3 +207,30 @@ templ Slice(props *Props) {
 		}
 	</ul>
 }
+
+templ UrnSlice(props *Props, lookup *lookupUrnSlice) {
+	switch props.Mode {
+		case ModeView :
+			for i := 0; i < len(lookup.objects); i++ {
+				<span class="uk-tag uk-tag-primary m-px">{ TitleOf(lookup.objects[i]) }</span>
+			}
+		case ModeEdit, ModeCreate:
+			<uk-select
+				name={ props.Name.String() }
+				id={ props.Name.String() }
+				searchable?={ lookup.Len() > 10 || lookup.Len() < 0 }
+				cls-custom="button: uk-input-fake w-full; dropdown: w-full"
+				multiple
+			>
+				<select hidden multiple>
+					for key, label := range lookup.Choices() {
+						if lookup.Contains(key) {
+							<option value={ key } selected>{ label }</option>
+						} else {
+							<option value={ key }>{ label }</option>
+						}
+					}
+				</select>
+			</uk-select>
+	}
+}

--- a/render/html_edit_templ.go
+++ b/render/html_edit_templ.go
@@ -1091,4 +1091,161 @@ func Slice(props *Props) templ.Component {
 	})
 }
 
+func UrnSlice(props *Props, lookup *lookupUrnSlice) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var63 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var63 == nil {
+			templ_7745c5c3_Var63 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		switch props.Mode {
+		case ModeView:
+			for i := 0; i < len(lookup.objects); i++ {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<span class=\"uk-tag uk-tag-primary m-px\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var64 string
+				templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(TitleOf(lookup.objects[i]))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 215, Col: 73}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</span>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+		case ModeEdit, ModeCreate:
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<uk-select name=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var65 string
+			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 219, Col: 30}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "\" id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var66 string
+			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 220, Col: 28}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if lookup.Len() > 10 || lookup.Len() < 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, " searchable")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, " cls-custom=\"button: uk-input-fake w-full; dropdown: w-full\" multiple><select hidden multiple>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for key, label := range lookup.Choices() {
+				if lookup.Contains(key) {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<option value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var67 string
+					templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(key)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 228, Col: 26}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "\" selected>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var68 string
+					templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 228, Col: 45}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</option>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				} else {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<option value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var69 string
+					templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(key)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 230, Col: 26}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var70 string
+					templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 230, Col: 36}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "</option>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</select></uk-select>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/render/html_list_templ.go
+++ b/render/html_list_templ.go
@@ -412,14 +412,14 @@ func hxListElementRow(v folio.Object) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if StringOf(v, "Icon") != "" {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<img class=\"h-12 w-12 flex-none rounded-full object-contain bg-gray-50\" src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<img class=\"h-12 w-12 flex-none rounded-full object-contain bg-gray-50\" src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(StringOf(v, "Icon"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_list.templ`, Line: 107, Col: 101}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_list.templ`, Line: 106, Col: 101}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {

--- a/render/lookup_test.go
+++ b/render/lookup_test.go
@@ -94,6 +94,7 @@ func TestUrn(t *testing.T) {
 		// Find the product field
 		rv := reflect.Indirect(reflect.ValueOf(test))
 		field, _ := rv.Type().FieldByName("Product")
+		fv := rv.FieldByName("Product")  // Get the field value
 
 		// Create a lookup for the urn & init
 		enum := lookupForUrn()
@@ -102,13 +103,168 @@ func TestUrn(t *testing.T) {
 				Registry: registry,
 				Store:    db,
 			},
-			Value:  rv,
+			Value:  fv,  // Use the field value, not the struct
 			Field:  field,
 			Parent: test,
 		}))
 		assert.NotNil(t, enum)
 	})
+}
 
+func TestUrnSlice(t *testing.T) {
+	testStorage(func(db folio.Storage, registry folio.Registry) {
+		// Create some test products
+		phone, err := folio.New("default", func(obj *Product) error {
+			obj.Name = "phone"
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, phone)
+		
+		laptop, err := folio.New("default", func(obj *Product) error {
+			obj.Name = "laptop"
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, laptop)
+		
+		tablet, err := folio.New("default", func(obj *Product) error {
+			obj.Name = "tablet"
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, tablet)
+
+		// Insert products into the database
+		_, err = db.Insert(phone, "test")
+		assert.NoError(t, err)
+		_, err = db.Insert(laptop, "test")
+		assert.NoError(t, err)
+		_, err = db.Insert(tablet, "test")
+		assert.NoError(t, err)
+
+		// Create a test struct with a slice of URNs
+		test := &struct {
+			folio.Meta  `kind:"mock" json:",inline"`
+			Inventory []folio.URN `kind:"product"`
+		}{
+			Inventory: []folio.URN{phone.URN(), laptop.URN()},
+		}
+
+		// Find the inventory field
+		rv := reflect.Indirect(reflect.ValueOf(test))
+		field, _ := rv.Type().FieldByName("Inventory")
+		fv := rv.FieldByName("Inventory")
+
+		// Create a lookup for the URN slice & initialize it
+		lookup := lookupForUrnSlice()
+		props := &Props{
+			Context: &Context{
+				Registry: registry,
+				Store:    db,
+				Namespace: "default",
+			},
+			Value:  fv,
+			Field:  field,
+			Parent: test,
+		}
+		
+		// Test initialization
+		assert.True(t, lookup.Init(props))
+		assert.NotNil(t, lookup)
+		assert.Equal(t, 2, len(lookup.objects))
+		
+		// Test Current - should return empty values since multiple are selected
+		k, v := lookup.Current()
+		assert.Equal(t, "", k)
+		assert.Equal(t, "", v)
+		
+		// Test Choices - should return all available products
+		var keys, values []string
+		for k, v := range lookup.Choices() {
+			keys = append(keys, k)
+			values = append(values, v)
+		}
+		assert.Equal(t, 3, lookup.Len())
+		assert.Equal(t, 3, len(keys))
+		
+		// Verify the objects were loaded correctly
+		assert.Equal(t, "phone", lookup.objects[0].(*Product).Name)
+		assert.Equal(t, "laptop", lookup.objects[1].(*Product).Name)
+		
+		// Test initialization with a non-URN slice
+		invalidTest := &struct {
+			folio.Meta  `kind:"mock" json:",inline"`
+			Tags []string
+		}{
+			Tags: []string{"tag1", "tag2"},
+		}
+		
+		rv = reflect.Indirect(reflect.ValueOf(invalidTest))
+		field, _ = rv.Type().FieldByName("Tags")
+		fv = rv.FieldByName("Tags")
+		
+		props.Value = fv
+		props.Field = field
+		props.Parent = invalidTest
+		
+		// Should not initialize for non-URN slice
+		assert.False(t, lookup.Init(props))
+	})
+}
+
+func TestUrnSliceEmpty(t *testing.T) {
+	testStorage(func(db folio.Storage, registry folio.Registry) {
+		// Create a test struct with an empty slice of URNs
+		test := &struct {
+			folio.Meta  `kind:"mock" json:",inline"`
+			Inventory []folio.URN `kind:"product"`
+		}{
+			Inventory: []folio.URN{},
+		}
+
+		// Find the inventory field
+		rv := reflect.Indirect(reflect.ValueOf(test))
+		field, _ := rv.Type().FieldByName("Inventory")
+		fv := rv.FieldByName("Inventory")
+
+		// Create a lookup for the URN slice & initialize it
+		lookup := lookupForUrnSlice()
+		props := &Props{
+			Context: &Context{
+				Registry: registry,
+				Store:    db,
+				Namespace: "default",
+			},
+			Value:  fv,
+			Field:  field,
+			Parent: test,
+		}
+		
+		// Test initialization with empty slice
+		assert.True(t, lookup.Init(props))
+		assert.NotNil(t, lookup)
+		assert.Equal(t, 0, len(lookup.objects))
+		
+		// Test with no kind tag
+		invalidTest := &struct {
+			folio.Meta  `kind:"mock" json:",inline"`
+			References []folio.URN
+		}{
+			References: []folio.URN{},
+		}
+		
+		rv = reflect.Indirect(reflect.ValueOf(invalidTest))
+		field, _ = rv.Type().FieldByName("References")
+		fv = rv.FieldByName("References")
+		
+		props.Value = fv
+		props.Field = field
+		props.Parent = invalidTest
+		
+		// Should not initialize without a kind tag
+		assert.False(t, lookup.Init(props))
+	})
 }
 
 func testStorage(fn func(db folio.Storage, registry folio.Registry)) {

--- a/render/parse.go
+++ b/render/parse.go
@@ -93,7 +93,7 @@ func hydrate(reader io.Reader, typ folio.Type, dst folio.Object, vd errors.Valid
 				return false
 			}
 
-			// fmt.Printf(" - %s of %s, field: %s, type: %v\n", subpath, rv.Kind(), fd.Name, fd.Type.Kind())
+			//fmt.Printf(" - %s of %s, field: %s, type: %v\n", subpath, rv.Kind(), fd.Name, fd.Type.Kind())
 
 			switch rv.Kind() {
 			case reflect.Struct:
@@ -138,6 +138,15 @@ func hydrate(reader io.Reader, typ folio.Type, dst folio.Object, vd errors.Valid
 		case reflect.Slice:
 			if rv.Type().Elem().Kind() == reflect.String {
 				rv.Set(reflect.ValueOf(asSlice[string](value)))
+			} else if rv.Type().Elem().Name() == "URN" {
+				// Handle slices of URNs
+				var urns []folio.URN
+				for _, e := range value.Array() {
+					if urn, err := folio.ParseURN(e.String()); err == nil {
+						urns = append(urns, urn)
+					}
+				}
+				rv.Set(reflect.ValueOf(urns))
 			}
 		default:
 			errDecode = fmt.Errorf("unable to decode %s, unsupported type %v", key.String(), rv.Kind())

--- a/render/render.go
+++ b/render/render.go
@@ -242,6 +242,10 @@ func renderValue(props *Props) (string, templ.Component) {
 	case reflect.Struct:
 		return "", Struct(props, renderStruct(props, value))
 	case reflect.Slice:
+		if lookup := lookupForUrnSlice(); lookup.Init(props) {
+			return label, UrnSlice(props, lookup)
+		}
+
 		switch value.Type().Elem().Kind() {
 		case reflect.Struct:
 			return "", Slice(props)


### PR DESCRIPTION
This pull request introduces several significant changes to the codebase, primarily focused on adding support for handling slices of URNs (`Uniform Resource Names`). The changes include new functionalities, updates to existing templates, and additional tests to ensure the new features work correctly.

### New Functionalities:
* Added a new type `lookupUrnSlice` to manage slices of URNs, including methods for initialization, fetching choices, and checking containment. (`render/lookup.go`)
* Introduced a new template function `UrnSlice` to render slices of URNs based on the mode (view, edit, create). (`render/html_edit.templ`)
* Added support for decoding slices of URNs in the `hydrate` function. (`render/parse.go`)

### Template Updates:
* Implemented the `UrnSlice` function in the Go template to handle the rendering of URN slices. (`render/html_edit_templ.go`)
* Updated `renderValue` to use the new `UrnSlice` function when appropriate. (`render/render.go`)

### Testing:
* Added tests for the new `lookupUrnSlice` functionality, including initialization, choice fetching, and handling of empty slices. (`render/lookup_test.go`) [[1]](diffhunk://#diff-91278be2de19434aa500bce5a230f05434c73aefa2cf8db8c20ffdef2cf913f7R97) [[2]](diffhunk://#diff-91278be2de19434aa500bce5a230f05434c73aefa2cf8db8c20ffdef2cf913f7L105-R267)

### Code Cleanup:
* Removed commented-out code in the `main` function of `examples/company/main.go`. (`examples/company/main.go`)

These changes enhance the handling and rendering of URN slices, ensuring better data management and user interface consistency.