### PR TITLE
Enhance range input handling and validation

### DIFF
--- a/examples/company/model.go
+++ b/examples/company/model.go
@@ -12,7 +12,8 @@ import (
 type Person struct {
 	folio.Meta `kind:"person" json:",inline"`
 	Name       string    `json:"name" form:"rw" is:"required"`
-	Age        int       `json:"age" form:"rw" is:"range(0|130)"`
+	Age        int       `json:"age" form:"rw" is:"range(0|130|1)" desc:"Age in years"`
+	Rating     float64   `json:"rating" form:"rw" is:"range(0|10|0.1)" desc:"Performance rating (0-10)"`
 	Gender     string    `json:"gender" form:"rw" is:"required,in(male|female|prefer_not_to)"`
 	Country    string    `json:"country" form:"rw"`
 	Address    string    `json:"address" form:"rw"`
@@ -28,6 +29,7 @@ func NewPerson() *Person {
 		p.Name = gofakeit.Name()
 		p.Address = gofakeit.Address().Address
 		p.Age = gofakeit.Number(18, 65)
+		p.Rating = float64(gofakeit.Number(0, 100)) / 10.0 // Rating between 0.0 and 10.0
 		p.Phone = gofakeit.Phone()
 		p.JobTitle = gofakeit.JobTitle()
 		p.Country = gofakeit.Country()
@@ -63,11 +65,14 @@ func (p *Person) Status() string {
 // ---------------------------------- Company ----------------------------------
 
 type Company struct {
-	folio.Meta `kind:"company" json:",inline"`
-	Name       string   `json:"name" form:"rw" is:"required"`
-	Sector     string   `json:"sector" form:"rw" is:"required,in(tech|finance|health)"`
-	Year       int      `json:"year" form:"rw" is:"range(1800|2021)"`
-	Tags       []string `json:"tags" form:"rw" is:"min(1)"`
+	folio.Meta   `kind:"company" json:",inline"`
+	Name         string   `json:"name" form:"rw" is:"required"`
+	Sector       string   `json:"sector" form:"rw" is:"required,in(tech|finance|health)"`
+	Year         int      `json:"year" form:"rw" is:"range(1800|2025|5)" desc:"Founded year (in 5-year increments)"`
+	ValuationM   float64  `json:"valuationM" form:"rw" is:"range(0|1000|10)" desc:"Valuation in millions USD"`
+	EmployeeSize int      `json:"employeeSize" form:"rw" is:"range(1|10000|10)" desc:"Number of employees"`
+	Revenue      int      `json:"revenue" form:"rw" is:"range(0|1000000|1)" desc:"Annual revenue (too many steps, shows input)"`
+	Tags         []string `json:"tags" form:"rw" is:"min(1)"`
 }
 
 func (c *Company) Title() string {
@@ -82,7 +87,10 @@ func NewCompany() *Company {
 	c, err := folio.New("default", func(c *Company) error {
 		c.Name = gofakeit.Company()
 		c.Sector = gofakeit.RandomString([]string{"tech", "finance", "health"})
-		c.Year = gofakeit.Number(1800, 2021)
+		c.Year = gofakeit.Number(1800, 2025)
+		c.ValuationM = float64(gofakeit.Number(1, 100)) * 10.0 // Valuation between 10M and 1000M
+		c.EmployeeSize = gofakeit.Number(1, 1000) * 10         // Employee size in multiples of 10
+		c.Revenue = gofakeit.Number(10000, 500000)             // Revenue with too many steps for slider
 		return nil
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kelindar/folio
 go 1.25.0
 
 require (
-	github.com/a-h/templ v0.3.924
+	github.com/a-h/templ v0.3.943
 	github.com/angelofallars/htmx-go v0.5.0
 	github.com/ncruces/go-sqlite3 v0.27.1
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/a-h/templ v0.3.924 h1:t5gZqTneXqvehpNZsgtnlOscnBboNh9aASBH2MgV/0k=
 github.com/a-h/templ v0.3.924/go.mod h1:FFAu4dI//ESmEN7PQkJ7E7QfnSEMdcnu7QrAY8Dn334=
+github.com/a-h/templ v0.3.943 h1:o+mT/4yqhZ33F3ootBiHwaY4HM5EVaOJfIshvd5UNTY=
+github.com/a-h/templ v0.3.943/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
 github.com/angelofallars/htmx-go v0.5.0 h1:L7M48cCH7nX8cV5wRYn04pN6AE4qNdh86iTbuKxhnIo=
 github.com/angelofallars/htmx-go v0.5.0/go.mod h1:izXk6A+Jllc3vXs1dUvxUJs/jE0weiEC07ZPlCVi4cc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.work.sum
+++ b/go.work.sum
@@ -63,6 +63,7 @@ golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
+golang.org/x/telemetry v0.0.0-20250710130107-8d8967aff50b/go.mod h1:4ZwOYna0/zsOKwuR5X/m0QFOJpSZvAxFfkQT+Erd9D4=
 golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=

--- a/render/assets/style.css
+++ b/render/assets/style.css
@@ -2,8 +2,10 @@
 
 :root {
   font-family: "Rubik", Inter, sans-serif;
-  font-feature-settings: "liga" 1, "calt" 1; /* fix for Chrome */
+  font-feature-settings: "liga" 1, "calt" 1;
+  /* fix for Chrome */
 }
+
 @supports (font-variation-settings: normal) {
   :root {
     font-family: "Rubik", InterVariable, sans-serif;
@@ -20,7 +22,8 @@
 /* Set the drawer width to 600px */
 .uk-offcanvas-bar {
   width: 600px !important;
-  left: -600px !important; /* Hide the drawer off-screen */
+  left: -600px !important;
+  /* Hide the drawer off-screen */
   padding: 0 !important;
   overflow-y: scroll !important;
 }
@@ -32,11 +35,11 @@
 }
 
 /* When the drawer is open, position it correctly */
-.uk-open > .uk-offcanvas-bar {
+.uk-open>.uk-offcanvas-bar {
   left: 0 !important;
 }
 
-.uk-offcanvas-flip .uk-open > .uk-offcanvas-bar {
+.uk-offcanvas-flip .uk-open>.uk-offcanvas-bar {
   right: 0 !important;
   left: auto !important;
 }
@@ -44,10 +47,11 @@
 /* Adjust reveal styles */
 .uk-offcanvas-reveal {
   width: 0 !important;
-  transition: width 0.3s ease-out !important; /* Ensure smooth transition */
+  transition: width 0.3s ease-out !important;
+  /* Ensure smooth transition */
 }
 
-.uk-open > .uk-offcanvas-reveal {
+.uk-open>.uk-offcanvas-reveal {
   width: 600px !important;
 }
 
@@ -93,6 +97,14 @@
   }
 }
 
+.uk-input-range-label {
+  font-size: 0.65rem;
+}
+
+.uk-input-range-label.top {
+  top: -1rem;
+}
+
 /* ---------------- Notification ---------------- */
 
 @keyframes anim-notify {
@@ -101,16 +113,19 @@
     transform: translateY(2rem);
     visibility: hidden;
   }
+
   10% {
     opacity: 1;
     transform: translateY(0);
     visibility: visible;
   }
+
   80% {
     opacity: 1;
     transform: translateY(0);
     visibility: visible;
   }
+
   100% {
     opacity: 0;
     transform: translateY(2rem);
@@ -141,7 +156,7 @@
   margin: 5px;
 }
 
-.divider > button {
+.divider>button {
   padding: 0;
   margin-top: 0px;
   margin-bottom: 0px;
@@ -180,7 +195,7 @@
   visibility: hidden;
 }
 
-.list-ul.uk-list-divider > :nth-child(n + 2) {
+.list-ul.uk-list-divider> :nth-child(n + 2) {
   margin-top: 1rem;
   border-top-width: 1px;
   border-color: hsl(var(--border));

--- a/render/html_edit.templ
+++ b/render/html_edit.templ
@@ -162,17 +162,16 @@ templ Range(props *Props, min, max, step float64) {
 		case ModeView :
 			<p>{ fmt.Sprintf("%v", props.Value.Interface()) }</p>
 		case ModeEdit, ModeCreate:
-			<input
-				type="range"
-				id={ props.Name.String() }
+			<uk-input-range
 				name={ props.Name.String() }
-				class="uk-range"
-				placeholder={ props.Desc }
-				value={ fmt.Sprintf("%v", props.Value.Interface()) }
 				min={ fmt.Sprintf("%v", min) }
 				max={ fmt.Sprintf("%v", max) }
 				step={ fmt.Sprintf("%v", step) }
-			/>
+				value={ fmt.Sprintf("%v", props.Value.Interface()) }
+				label=""
+				label-position="top"
+				class="w-full"
+			></uk-input-range>
 	}
 }
 

--- a/render/html_edit_templ.go
+++ b/render/html_edit_templ.go
@@ -861,98 +861,72 @@ func Range(props *Props, min, max, step float64) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		case ModeEdit, ModeCreate:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "<input type=\"range\" id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "<uk-input-range name=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 167, Col: 28}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 166, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\" name=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\" min=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var47 string
-			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", min))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 168, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 167, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "\" class=\"uk-range\" placeholder=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "\" max=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var48 string
-			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(props.Desc)
+			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", max))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 170, Col: 28}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 168, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\" step=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var49 string
-			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", props.Value.Interface()))
+			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", step))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 171, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 169, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "\" min=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var50 string
-			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", min))
+			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", props.Value.Interface()))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 172, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 170, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\" max=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var51 string
-			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", max))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 173, Col: 32}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "\" step=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var52 string
-			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%v", step))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 174, Col: 34}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\" label=\"\" label-position=\"top\" class=\"w-full\"></uk-input-range>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -977,9 +951,9 @@ func Struct(props *Props, children []templ.Component) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var53 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var53 == nil {
-			templ_7745c5c3_Var53 = templ.NopComponent
+		templ_7745c5c3_Var51 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var51 == nil {
+			templ_7745c5c3_Var51 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hxDivider(props.Name.Label()).Render(ctx, templ_7745c5c3_Buffer)
@@ -1012,9 +986,9 @@ func StructInline(props *Props, children []templ.Component) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var54 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var54 == nil {
-			templ_7745c5c3_Var54 = templ.NopComponent
+		templ_7745c5c3_Var52 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var52 == nil {
+			templ_7745c5c3_Var52 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		for _, child := range children {
@@ -1043,118 +1017,118 @@ func StructPtr(props *Props) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var55 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var55 == nil {
-			templ_7745c5c3_Var55 = templ.NopComponent
+		templ_7745c5c3_Var53 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var53 == nil {
+			templ_7745c5c3_Var53 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		switch props.Mode {
 		case ModeEdit, ModeCreate:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<div class=\"divider\"><button id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<div class=\"divider\"><button id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var54 string
+			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("add"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 196, Col: 25}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "\" class=\"uk-btn uk-btn-ghost text-xs\" uk-tooltip=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var55 string
+			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs("pos: top; title: Add " + props.Name.Label())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 198, Col: 62}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\" uk-toggle=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var56 string
-			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("add"))
+			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs("target: #" + props.ID("add"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 197, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 199, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "\" class=\"uk-btn uk-btn-ghost text-xs\" uk-tooltip=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var57 string
-			templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs("pos: top; title: Add " + props.Name.Label())
+			templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Context.Namespace, props.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 199, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 200, Col: 100}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "\" uk-toggle=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "\" hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var58 string
-			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs("target: #" + props.ID("add"))
+			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs("#" + props.ID("hx"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 200, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 201, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" hx-get=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" hx-swap=\"outerHTML\"><uk-icon icon=\"file-plus\"></uk-icon></button><div class=\"ml-10\" id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var59 string
-			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Context.Namespace, props.Name))
+			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("add"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 201, Col: 100}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 206, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\" hx-target=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\" hidden></div><span class=\"mr-10\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var60 string
-			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs("#" + props.ID("hx"))
+			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.Label())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 202, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 207, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\" hx-swap=\"outerHTML\"><uk-icon icon=\"file-plus\"></uk-icon></button><div class=\"ml-10\" id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</span></div><div id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var61 string
-			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("add"))
+			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("hx"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 207, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 209, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "\" hidden></div><span class=\"mr-10\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var62 string
-			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.Label())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 208, Col: 44}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</span></div><div id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var63 string
-			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("hx"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 210, Col: 27}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "\"><span class=\"text-gray-400 text-xs block text-center\">none</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "\"><span class=\"text-gray-400 text-xs block text-center\">none</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1179,80 +1153,102 @@ func Slice(props *Props) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var64 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var64 == nil {
-			templ_7745c5c3_Var64 = templ.NopComponent
+		templ_7745c5c3_Var62 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var62 == nil {
+			templ_7745c5c3_Var62 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<div class=\"divider\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<div class=\"divider\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		switch props.Mode {
 		case ModeEdit, ModeCreate:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<button type=\"button\" class=\"uk-btn uk-btn-ghost text-xs\" uk-tooltip=\"title: Add new item; pos: top\" hx-get=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<button type=\"button\" class=\"uk-btn uk-btn-ghost text-xs\" uk-tooltip=\"title: Add new item; pos: top\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var65 string
-			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Parent.URN().Namespace, props.Name))
+			var templ_7745c5c3_Var63 string
+			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Parent.URN().Namespace, props.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 224, Col: 105}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 223, Col: 105}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "\" hx-target=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var66 string
-			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs("#" + props.Name.String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 225, Col: 42}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\" hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "\" hx-swap=\"beforeend\"><uk-icon icon=\"list-plus\"></uk-icon></button> ")
+			var templ_7745c5c3_Var64 string
+			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs("#" + props.Name.String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 224, Col: 42}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "\" hx-swap=\"beforeend\"><uk-icon icon=\"list-plus\"></uk-icon></button> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		default:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<div class=\"ml-10\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div class=\"ml-10\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var67 string
-		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.Label())
+		var templ_7745c5c3_Var65 string
+		templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.Label())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 233, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 232, Col: 28}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</span> <button type=\"button\" class=\"uk-btn uk-btn-ghost text-xs\" uk-tooltip=\"title: Collapse/Expand; pos: top\" uk-toggle=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</span> <button type=\"button\" class=\"uk-btn uk-btn-ghost text-xs\" uk-tooltip=\"title: Collapse/Expand; pos: top\" uk-toggle=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var66 string
+		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs("animation: uk-animation-fade; target: ." + props.ID("toggle"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 237, Col: 77}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var67 = []any{props.ID("toggle")}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var67...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "<uk-icon icon=\"fold-vertical\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var68 string
-		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs("animation: uk-animation-fade; target: ." + props.ID("toggle"))
+		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var67).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 238, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "\"></uk-icon> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1261,7 +1257,7 @@ func Slice(props *Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<uk-icon icon=\"fold-vertical\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<uk-icon icon=\"unfold-vertical\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1274,64 +1270,42 @@ func Slice(props *Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\"></uk-icon> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" hidden></uk-icon></button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var71 = []any{props.ID("toggle")}
+		var templ_7745c5c3_Var71 = []any{"uk-list list-ul " + props.ID("toggle")}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var71...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<uk-icon icon=\"unfold-vertical\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<ul id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var72 string
-		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var71).String())
+		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 244, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "\" hidden></uk-icon></button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "\" uk-sortable=\"handle: .uk-sortable-handle\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var73 = []any{"uk-list list-ul " + props.ID("toggle")}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var73...)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "<ul id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var74 string
-		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 245, Col: 26}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" uk-sortable=\"handle: .uk-sortable-handle\" class=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var75 string
-		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var73).String())
+		var templ_7745c5c3_Var73 string
+		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var71).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1344,7 +1318,7 @@ func Slice(props *Props) templ.Component {
 				}
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</ul>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "</ul>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1368,165 +1342,165 @@ func UrnSlice(props *Props, lookup *lookupUrnSlice) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var76 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var76 == nil {
-			templ_7745c5c3_Var76 = templ.NopComponent
+		templ_7745c5c3_Var74 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var74 == nil {
+			templ_7745c5c3_Var74 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		switch props.Mode {
 		case ModeView:
 			for i := 0; i < len(lookup.objects); i++ {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "<span class=\"uk-tag uk-tag-primary m-px\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "<span class=\"uk-tag uk-tag-primary m-px\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var77 string
-				templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(TitleOf(lookup.objects[i]))
+				var templ_7745c5c3_Var75 string
+				templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(TitleOf(lookup.objects[i]))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 262, Col: 73}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 261, Col: 73}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		case ModeEdit, ModeCreate:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "<uk-select name=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "<uk-select name=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var78 string
-			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
+			var templ_7745c5c3_Var76 string
+			templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 266, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 265, Col: 30}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "\" id=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var79 string
-			templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 267, Col: 28}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "\" id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "\"")
+			var templ_7745c5c3_Var77 string
+			templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 266, Col: 28}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if lookup.Len() > 10 || lookup.Len() < 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, " searchable")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, " searchable")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, " cls-custom=\"button: uk-input-fake justify-between w-full; dropdown: w-full\" icon=\"chevron-down\" multiple><select hidden multiple>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, " cls-custom=\"button: uk-input-fake justify-between w-full; dropdown: w-full\" icon=\"chevron-down\" multiple><select hidden multiple>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for key, label := range lookup.Choices() {
 				if lookup.Contains(key) {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "<option data-keywords=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "<option data-keywords=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var78 string
+					templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 275, Col: 36}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\" value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var79 string
+					templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(key)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 275, Col: 50}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\" selected>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var80 string
 					templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 276, Col: 36}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 275, Col: 69}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\" value=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "</option>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				} else {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "<option data-keywords=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var81 string
-					templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(key)
+					templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 276, Col: 50}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 277, Col: 36}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "\" selected>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\" value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var82 string
-					templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 276, Col: 69}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 277, Col: 50}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "</option>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				} else {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "<option data-keywords=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var83 string
 					templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 278, Col: 36}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 277, Col: 60}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\" value=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var84 string
-					templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(key)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 278, Col: 50}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var85 string
-					templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(label)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 278, Col: 60}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "</option>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "</option>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "</select></uk-select>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "</select></uk-select>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/render/parse.go
+++ b/render/parse.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kelindar/folio"
@@ -17,6 +18,7 @@ import (
 var (
 	exIn    = regexp.MustCompile(`^in\((.*)\)`)
 	exFlags = regexp.MustCompile(`^flags\((.*)\)`)
+	exRange = regexp.MustCompile(`^range\((.*)\)`)
 )
 
 // ---------------------------------- Struct Fields ----------------------------------
@@ -35,6 +37,10 @@ func isEmail(field reflect.StructField) bool {
 
 func isRequired(field reflect.StructField) bool {
 	return strings.Contains(field.Tag.Get("is"), "required")
+}
+
+func isRange(field reflect.StructField) bool {
+	return strings.Contains(field.Tag.Get("is"), "range(")
 }
 
 // Parses oneof tag from validator e.g.: "required,oneof=male female prefer_not_to"
@@ -65,6 +71,37 @@ func decodeFlags(field reflect.StructField) ([]string, bool) {
 		}
 	}
 	return nil, false
+}
+
+// Parses range tag from validator e.g.: "required,range(0|100|1)"
+func decodeRange(field reflect.StructField) (min, max, step float64, hasStep bool) {
+	if !isRange(field) {
+		return 0, 0, 0, false
+	}
+
+	fields := strings.Split(field.Tag.Get("is"), ",")
+	for _, field := range fields {
+		if out := exRange.FindAllStringSubmatch(field, -1); len(out) > 0 {
+			params := strings.Split(out[0][1], "|")
+			if len(params) >= 2 {
+				minVal, err1 := strconv.ParseFloat(params[0], 64)
+				maxVal, err2 := strconv.ParseFloat(params[1], 64)
+				if err1 != nil || err2 != nil {
+					return 0, 0, 0, false
+				}
+
+				if len(params) == 3 {
+					stepVal, err3 := strconv.ParseFloat(params[2], 64)
+					if err3 != nil || stepVal <= 0 {
+						return 0, 0, 0, false
+					}
+					return minVal, maxVal, stepVal, true
+				}
+				return minVal, maxVal, 1, false
+			}
+		}
+	}
+	return 0, 0, 0, false
 }
 
 func decodeKind(field reflect.StructField, registry folio.Registry) (folio.Type, bool) {

--- a/render/parse_test.go
+++ b/render/parse_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -162,4 +163,66 @@ func TestUnmarshal_Slice_Overwrite(t *testing.T) {
 	assert.Equal(t, "electric", car.Engines[1].Type)
 	assert.Equal(t, 200, car.Engines[1].Power)
 	assert.Equal(t, 2, len(car.Engines))
+}
+
+func TestDecodeRange(t *testing.T) {
+	tests := map[string]struct {
+		tag     string
+		min     float64
+		max     float64
+		step    float64
+		hasStep bool
+	}{
+		"no range tag":             {tag: `is:"required"`, min: 0, max: 0, step: 0, hasStep: false},
+		"basic range":              {tag: `is:"range(0|100)"`, min: 0, max: 100, step: 1, hasStep: false},
+		"range with step":          {tag: `is:"range(0|100|0.5)"`, min: 0, max: 100, step: 0.5, hasStep: true},
+		"range with integer step":  {tag: `is:"range(1|10|1)"`, min: 1, max: 10, step: 1, hasStep: true},
+		"complex tag with range":   {tag: `is:"required,range(0|100|0.1),min(0)"`, min: 0, max: 100, step: 0.1, hasStep: true},
+		"negative range":           {tag: `is:"range(-10|10|0.5)"`, min: -10, max: 10, step: 0.5, hasStep: true},
+		"decimal range":            {tag: `is:"range(0.5|10.5|0.25)"`, min: 0.5, max: 10.5, step: 0.25, hasStep: true},
+		"invalid step zero":        {tag: `is:"range(0|100|0)"`, min: 0, max: 0, step: 0, hasStep: false},
+		"invalid step negative":    {tag: `is:"range(0|100|-1)"`, min: 0, max: 0, step: 0, hasStep: false},
+		"invalid step non-numeric": {tag: `is:"range(0|100|step)"`, min: 0, max: 0, step: 0, hasStep: false},
+		"invalid min non-numeric":  {tag: `is:"range(min|100|1)"`, min: 0, max: 0, step: 0, hasStep: false},
+		"invalid max non-numeric":  {tag: `is:"range(0|max|1)"`, min: 0, max: 0, step: 0, hasStep: false},
+		"incomplete range":         {tag: `is:"range(0)"`, min: 0, max: 0, step: 0, hasStep: false},
+		"empty range":              {tag: `is:"range()"`, min: 0, max: 0, step: 0, hasStep: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			field := reflect.StructField{
+				Tag: reflect.StructTag(tc.tag),
+			}
+			min, max, step, hasStep := decodeRange(field)
+			assert.Equal(t, tc.min, min, "min mismatch")
+			assert.Equal(t, tc.max, max, "max mismatch")
+			assert.Equal(t, tc.step, step, "step mismatch")
+			assert.Equal(t, tc.hasStep, hasStep, "hasStep mismatch")
+		})
+	}
+}
+
+func TestRangeStepLimit(t *testing.T) {
+	tests := map[string]struct {
+		min          float64
+		max          float64
+		step         float64
+		expectSlider bool
+	}{
+		"exactly 100 steps":        {min: 0, max: 100, step: 1, expectSlider: true},
+		"101 steps":                {min: 0, max: 101, step: 1, expectSlider: false},
+		"50 steps with decimals":   {min: 0, max: 10, step: 0.2, expectSlider: true},
+		"200 steps":                {min: 0, max: 200, step: 1, expectSlider: false},
+		"large range small step":   {min: 0, max: 1000000, step: 1, expectSlider: false},
+		"reasonable decimal steps": {min: 0, max: 10, step: 0.1, expectSlider: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			steps := (tc.max - tc.min) / tc.step
+			shouldUseSlider := steps <= 100
+			assert.Equal(t, tc.expectSlider, shouldUseSlider, "step limit logic mismatch")
+		})
+	}
 }

--- a/render/render.go
+++ b/render/render.go
@@ -254,6 +254,9 @@ func renderValue(props *Props) (string, templ.Component) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 		reflect.Float32, reflect.Float64:
+		if min, max, step, hasStep := decodeRange(props.Field); hasStep && (max-min)/step <= 100 {
+			return label, Range(props, min, max, step)
+		}
 		return label, Number(props)
 	case reflect.Bool:
 		return label, Bool(props)

--- a/validate/validators.go
+++ b/validate/validators.go
@@ -887,7 +887,7 @@ func MaxStringLength(str string, params ...string) bool {
 
 // Range checks string's length
 func Range(str string, params ...string) bool {
-	if len(params) != 2 {
+	if len(params) != 2 && len(params) != 3 {
 		return false
 	}
 
@@ -899,6 +899,13 @@ func Range(str string, params ...string) bool {
 	// Check if all conversions are successful
 	if err1 != nil || err2 != nil || err3 != nil {
 		return false
+	}
+
+	// If step is provided, validate it's a positive number
+	if len(params) == 3 {
+		if step, err := convert.Float64(params[2]); err != nil || step <= 0 {
+			return false
+		}
 	}
 
 	if lo > hi {

--- a/validate/validators_test.go
+++ b/validate/validators_test.go
@@ -2165,6 +2165,17 @@ func TestRange(t *testing.T) {
 		"invalid params length":              {input: "5", params: []string{"1"}, expected: false},
 		"range with left greater than right": {input: "5", params: []string{"10", "1"}, expected: true},
 		"string":                             {input: "apple", params: []string{"banana", "zebra"}, expected: false},
+		"within range with step":             {input: "5", params: []string{"1", "10", "0.5"}, expected: true},
+		"below range with step":              {input: "0", params: []string{"1", "10", "0.5"}, expected: false},
+		"above range with step":              {input: "11", params: []string{"1", "10", "0.5"}, expected: false},
+		"exactly min with step":              {input: "1", params: []string{"1", "10", "0.5"}, expected: true},
+		"exactly max with step":              {input: "10", params: []string{"1", "10", "0.5"}, expected: true},
+		"float within range with step":       {input: "5.5", params: []string{"1", "10", "0.5"}, expected: true},
+		"invalid step zero":                  {input: "5", params: []string{"1", "10", "0"}, expected: false},
+		"invalid step negative":              {input: "5", params: []string{"1", "10", "-0.5"}, expected: false},
+		"invalid step non-numeric":           {input: "5", params: []string{"1", "10", "step"}, expected: false},
+		"valid step integer":                 {input: "5", params: []string{"1", "10", "1"}, expected: true},
+		"step larger than range":             {input: "5", params: []string{"1", "10", "20"}, expected: true},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the data models, UI components, and styling. The most significant changes are the addition of new fields and validation rules to the `Person` and `Company` models, the replacement of native range inputs with a custom `uk-input-range` component for better UI consistency, and improvements to CSS for range input labels and notification animations. There are also minor dependency updates and code cleanups.

**Model Enhancements:**

* Added new fields to `Person` and `Company` models, including `rating` for `Person` and `valuationM`, `employeeSize`, and `revenue` for `Company`, with improved validation rules and descriptions for range-based fields. (`examples/company/model.go` [[1]](diffhunk://#diff-e0263286138eb76d23a9c38f2b95237b58353eaf1d2112832528ec127db3d929L15-R16) [[2]](diffhunk://#diff-e0263286138eb76d23a9c38f2b95237b58353eaf1d2112832528ec127db3d929L69-R74)
* Updated the `NewPerson` and `NewCompany` functions to initialize the new fields with realistic fake data. (`examples/company/model.go` [[1]](diffhunk://#diff-e0263286138eb76d23a9c38f2b95237b58353eaf1d2112832528ec127db3d929R32) [[2]](diffhunk://#diff-e0263286138eb76d23a9c38f2b95237b58353eaf1d2112832528ec127db3d929L85-R93)

**UI Component Refactoring:**

* Replaced the native `<input type="range">` with a custom `<uk-input-range>` component in the `Range` template, improving customization and consistency across the UI. (`render/html_edit.templ` [[1]](diffhunk://#diff-af70252654491b2b28e87c77dbb321fe866c4978edc6e4e141fa7c23b1d10531L165-R174) `render/html_edit_templ.go` [[2]](diffhunk://#diff-9052bdd31ff8d79fa3b07fbe5637dfbccd6a839d6cc8400cdc7ba324e24e3fa0L864-R929)
* Minor variable renaming and code cleanup in generated template code for struct rendering. (`render/html_edit_templ.go` [[1]](diffhunk://#diff-9052bdd31ff8d79fa3b07fbe5637dfbccd6a839d6cc8400cdc7ba324e24e3fa0L980-R956) [[2]](diffhunk://#diff-9052bdd31ff8d79fa3b07fbe5637dfbccd6a839d6cc8400cdc7ba324e24e3fa0L1015-R991)

**Styling Improvements:**

* Added new CSS classes for range input labels and adjusted font size and positioning for better appearance. (`render/assets/style.css` [render/assets/style.cssR100-R107](diffhunk://#diff-567663fc4ed3da37a3fa4172de2917e941b59a247e5d9077c284a1b7f577298cR100-R107))
* Improved notification animation timing and added clarifying comments for better maintainability. (`render/assets/style.css` [render/assets/style.cssR116-R128](diffhunk://#diff-567663fc4ed3da37a3fa4172de2917e941b59a247e5d9077c284a1b7f577298cR116-R128))
* Minor formatting and comment improvements in CSS for readability. (`render/assets/style.css` [[1]](diffhunk://#diff-567663fc4ed3da37a3fa4172de2917e941b59a247e5d9077c284a1b7f577298cL5-R8) [[2]](diffhunk://#diff-567663fc4ed3da37a3fa4172de2917e941b59a247e5d9077c284a1b7f577298cL23-R26) [[3]](diffhunk://#diff-567663fc4ed3da37a3fa4172de2917e941b59a247e5d9077c284a1b7f577298cL47-R51)

**Dependency Updates:**

* Updated the `github.com/a-h/templ` dependency to a newer version. (`go.mod` [go.modL6-R6](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L6-R6))
* Added a new checksum for `golang.org/x/telemetry` in the workspace sum file. (`go.work.sum` [go.work.sumR66](diffhunk://#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R66))