### PR TITLE
Fix slice path

### DIFF
--- a/examples/company/model.go
+++ b/examples/company/model.go
@@ -117,7 +117,7 @@ type Vehicle struct {
 		Type   string `json:"type" form:"rw" is:"required,in(third_party|comprehensive)"`
 		Term   int    `json:"term" form:"rw" is:"min(1)"`
 		Extras []struct {
-			Person folio.URN `json:"person" form:"rw" is:"required" kind:"person"`
+			Person folio.URN `json:"person" form:"rw" is:"required" kind:"person" query:"namespace=*"`
 			Age    int       `json:"age" form:"rw" is:"min(0)"`
 		} `json:"drivers" form:"rw"`
 	} `json:"insurance" form:"rw"`

--- a/render/html_edit.templ
+++ b/render/html_edit.templ
@@ -220,7 +220,7 @@ templ Slice(props *Props) {
 					type="button"
 					class="uk-btn uk-btn-ghost text-xs"
 					uk-tooltip="title: Add new item; pos: top"
-					hx-get={ fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Parent.URN().Namespace, props.Name) }
+					hx-get={ fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Context.Namespace, props.Name) }
 					hx-target={ "#" + props.ID("list") }
 					hx-swap="beforeend"
 				>

--- a/render/html_edit_templ.go
+++ b/render/html_edit_templ.go
@@ -5,13 +5,13 @@ package render
 
 //lint:file-ignore SA4006 This context is only used if a nested component is present.
 
+import "github.com/a-h/templ"
+import templruntime "github.com/a-h/templ/runtime"
+
 import (
 	"fmt"
-	"strings"
-
-	"github.com/a-h/templ"
-	templruntime "github.com/a-h/templ/runtime"
 	"github.com/kelindar/folio/internal/convert"
+	"strings"
 )
 
 func String(props *Props) templ.Component {
@@ -1169,9 +1169,9 @@ func Slice(props *Props) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var63 string
-			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Parent.URN().Namespace, props.Name))
+			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/make/%s?ns=%s&path=%s", props.Kind, props.Context.Namespace, props.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 223, Col: 105}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 223, Col: 100}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 			if templ_7745c5c3_Err != nil {
@@ -1181,10 +1181,10 @@ func Slice(props *Props) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var66 string
-			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs("#" + props.Name.String())
+			var templ_7745c5c3_Var64 string
+			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs("#" + props.ID("list"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 225, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 224, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 			if templ_7745c5c3_Err != nil {
@@ -1283,10 +1283,10 @@ func Slice(props *Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var74 string
-		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name.String())
+		var templ_7745c5c3_Var72 string
+		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(props.ID("list"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 245, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `render/html_edit.templ`, Line: 244, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
This pull request refactors how the namespace and element IDs are handled in the HTML edit rendering components, improving consistency and correctness when generating dynamic UI elements. It also updates import ordering for clarity and maintainability.

**Rendering and UI improvements:**

* Updated the `hx-get` attribute in the `Slice` component to use `props.Context.Namespace` instead of `props.Parent.URN().Namespace`, ensuring the correct namespace is used when adding new items. [[1]](diffhunk://#diff-af70252654491b2b28e87c77dbb321fe866c4978edc6e4e141fa7c23b1d10531L223-R223) [[2]](diffhunk://#diff-9052bdd31ff8d79fa3b07fbe5637dfbccd6a839d6cc8400cdc7ba324e24e3fa0L1172-R1174)
* Changed element targeting and referencing in the `Slice` component from using `props.Name.String()` to `props.ID("list")`, providing more reliable and unique element IDs for dynamic lists. [[1]](diffhunk://#diff-9052bdd31ff8d79fa3b07fbe5637dfbccd6a839d6cc8400cdc7ba324e24e3fa0L1184-R1187) [[2]](diffhunk://#diff-9052bdd31ff8d79fa3b07fbe5637dfbccd6a839d6cc8400cdc7ba324e24e3fa0L1286-R1289)

**Codebase maintenance:**

* Reordered imports in `render/html_edit_templ.go` for better organization and clarity, moving third-party imports to the top and grouping standard library imports together.

**Model definition update:**

* Added a `query:"namespace=*"` tag to the `Person` field in the `Vehicle` struct, allowing for more flexible querying by namespace in insurance driver definitions.