### PR TITLE
Enhance query filters to support existence checks

### DIFF
--- a/sqlite/storage.go
+++ b/sqlite/storage.go
@@ -163,9 +163,27 @@ func queryFilterByJSON(path string, values []string) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString("(json_extract(data, '$.")
-	sb.WriteString(path)
-	sb.WriteString("') IN (")
+	jsonPath := "json_extract(data, '$." + path + "')"
+
+	// Check if this is an existence-only filter (empty string value)
+	if len(values) == 1 && values[0] == "" {
+		// Existence check: field must be non-null and non-zero value
+		sb.WriteString("(")
+		sb.WriteString(jsonPath)
+		sb.WriteString(" IS NOT NULL AND ")
+		sb.WriteString(jsonPath)
+		sb.WriteString(" != '' AND ")
+		sb.WriteString(jsonPath)
+		sb.WriteString(" != 0 AND ")
+		sb.WriteString(jsonPath)
+		sb.WriteString(" != false)")
+		return sb.String()
+	}
+
+	// Standard equality filter
+	sb.WriteString("(")
+	sb.WriteString(jsonPath)
+	sb.WriteString(" IN (")
 
 	// Write the values as a SQL 'IN' list
 	for i, v := range values {

--- a/types.go
+++ b/types.go
@@ -224,8 +224,11 @@ Example query: "namespace=company;state=active;filter=age:30;match={Name}"
  2. **state**: Indicates the states to filter by. Multiple states can be separated by commas.
     Example: `state=active,inactive`
 
- 3. **filter**: Defines filters to apply. Each filter is specified as `field:value`, and multiple filters can be separated by commas.
-    Example: `filter=age:30,income:1000`
+ 3. **filter**: Defines filters to apply. Each filter is specified as `field:value` for equality checks,
+    or just `field` (without colon) for existence checks (non-nil and non-zero). Multiple filters can be
+    separated by commas.
+    Example: `filter=age:30,income:1000` (equality checks)
+    Example: `filter=email` (existence check - matches records where email is set and non-empty)
 
  4. **match**: A full-text search query. This can include any search terms.
     Example: `match=software engineer`
@@ -339,6 +342,7 @@ func parseMatch(text string, query *Query, object any) error {
 }
 
 // populateFilters processes the filters and adds them to the Query struct.
+// Filters can be in the format "key:value" for equality checks or just "key" for existence checks.
 func populateFilters(query *Query, filterStr string) error {
 	filters := strings.Split(filterStr, ",")
 	for _, filter := range filters {
@@ -348,15 +352,20 @@ func populateFilters(query *Query, filterStr string) error {
 		}
 
 		kv := strings.SplitN(filter, ":", 2)
-		if len(kv) != 2 {
-			return fmt.Errorf("query: invalid filter format '%s'", filter)
+		key := strings.TrimSpace(kv[0])
+		if key == "" {
+			return fmt.Errorf("query: empty key in filter '%s'", filter)
 		}
 
-		key := strings.TrimSpace(kv[0])
-		value := strings.TrimSpace(kv[1])
-		if key == "" || value == "" {
-			return fmt.Errorf("query: empty key or value in filter '%s'", filter)
+		// If no value is provided, it's an existence check (empty string signals this)
+		var value string
+		if len(kv) == 2 {
+			value = strings.TrimSpace(kv[1])
+			if value == "" {
+				return fmt.Errorf("query: empty value in filter '%s'", filter)
+			}
 		}
+
 		query.Filters[key] = append(query.Filters[key], value)
 	}
 	return nil

--- a/types_test.go
+++ b/types_test.go
@@ -55,7 +55,7 @@ func TestParseQuery(t *testing.T) {
 		invalid bool
 	}{
 		"invalid namespace format": {query: "namespace=;state=active", invalid: true},
-		"invalid filter format":    {query: "namespace=company;filter=age;state=active", invalid: true},
+		"invalid filter key empty": {query: "namespace=company;filter=:value;state=active", invalid: true},
 		"invalid match format":     {query: "namespace=company;match=;", invalid: true},
 		"empty query string": {
 			query:  "",
@@ -90,6 +90,14 @@ func TestParseQuery(t *testing.T) {
 					"age": {"30"},
 				},
 				Match: "Alice",
+			},
+		},
+		"existence check filter": {
+			query: "filter=email",
+			expect: Query{
+				Filters: map[string][]string{
+					"email": {""},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This pull request updates the query filter system to support existence checks (i.e., filtering for fields that are set and non-empty) in addition to equality checks. It also updates documentation and tests to reflect and verify this new functionality.

**Query filtering improvements:**

* Updated the `queryFilterByJSON` function in `sqlite/storage.go` to support existence-only filters. Now, if a filter is provided without a value (e.g., `filter=email`), the SQL query checks that the field is non-null, non-empty, non-zero, and not false.

**Documentation updates:**

* Clarified in `types.go` that filters can be specified as `field:value` for equality checks or just `field` for existence checks. Provided examples for both cases.
* Updated the `populateFilters` function comment to explain the new filter format.

**Filter parsing logic:**

* Modified `populateFilters` in `types.go` to handle filters with and without values, treating filters without a value as existence checks and ensuring invalid cases (like empty keys or values) are properly handled.

**Testing improvements:**

* Updated and added test cases in `types_test.go` to cover the new existence check filter format and to improve validation of invalid filter formats. [[1]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092L58-R58) [[2]](diffhunk://#diff-02776af2e303aa4b13cf883561bfd1aa91a940389c39aae1b7abbaecc0d68092R95-R102)